### PR TITLE
feature(quest-options-button): creating separated component for optio…

### DIFF
--- a/generators/templates/Component/Component.test.tsx.hbs
+++ b/generators/templates/Component/Component.test.tsx.hbs
@@ -4,9 +4,10 @@ import { describe, it, expect } from 'vitest';
 import {{pascalCase name}} from '.';
 
 describe('{{pascalCase name}}', () => {
-  it('Should render {{pascalCase name}} component', () => {
-    render(<{{pascalCase name}} />);
+it('Should render {{pascalCase name}} component', () => {
+render(
+<{{pascalCase name}} />);
 
-    expect(screen.getByText(/{{pascalCase name}}/i)).toBeInTheDocument();
-  });
+expect(screen.getByText(/{{pascalCase name}}/i)).toBeInTheDocument();
+});
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,15 +4,10 @@ import { Container } from './styles';
 
 interface ButtonProps extends PropsWithChildren {
   onClick: () => void;
-  variation: 'primary' | 'bordered';
 }
 
-const Button: FC<ButtonProps> = ({ onClick, variation, children }) => {
-  return (
-    <Container onClick={onClick} variation={variation}>
-      {children}
-    </Container>
-  );
+const Button: FC<ButtonProps> = ({ onClick, children }) => {
+  return <Container onClick={onClick}>{children}</Container>;
 };
 
 export default Button;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,22 +1,13 @@
-import { type PropsWithChildren, type FC } from 'react';
+import { type FC, type PropsWithChildren } from 'react';
 
 import Button from './Button';
 
 interface WrapperProps extends PropsWithChildren {
   onClick?: () => void;
-  variation?: 'primary' | 'bordered';
 }
 
-const Wrapper: FC<WrapperProps> = ({
-  onClick = () => {},
-  variation = 'primary',
-  children,
-}) => {
-  return (
-    <Button onClick={onClick} variation={variation}>
-      {children}
-    </Button>
-  );
+const Wrapper: FC<WrapperProps> = ({ onClick = () => {}, children }) => {
+  return <Button onClick={onClick}>{children}</Button>;
 };
 
 export default Wrapper;

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 export const Container = styled.button`
   border-width: 1px;
@@ -9,31 +9,11 @@ export const Container = styled.button`
   padding-top: 15px;
   padding-bottom: 15px;
   transition: background-color 0.3s, color 0.3s;
+  color: var(--color-primary);
+  border-color: var(--color-secondary);
+  background-color: var(--color-secondary);
 
-  ${({ variation }: { variation: 'primary' | 'bordered' }) => {
-    if (variation === 'primary') {
-      return css`
-        color: var(--color-primary);
-        border-color: var(--color-secondary);
-        background-color: var(--color-secondary);
-
-        &:hover {
-          background-color: var(--color-secondary-light);
-        }
-      `;
-    }
-
-    return css`
-      color: var(--color-white);
-      border-color: var(--color-white);
-      background-color: transparent;
-
-      transition: background-color 0.3s;
-
-      &:hover {
-        background-color: var(--color-white);
-        color: var(--color-primary);
-      }
-    `;
-  }}
+  &:hover {
+    background-color: var(--color-secondary-light);
+  }
 `;

--- a/src/components/QuestOptionButton/QuestOptionButton.test.tsx
+++ b/src/components/QuestOptionButton/QuestOptionButton.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import QuestOptionButton from '.';
+
+describe('QuestOptionButton', () => {
+  it('Should render QuestOptionButton with correct children content', () => {
+    const children = 'example';
+
+    render(<QuestOptionButton>{children}</QuestOptionButton>);
+
+    expect(screen.getByText(children)).toBeInTheDocument();
+  });
+
+  it('Should call callback function when clicked', async () => {
+    const user = userEvent.setup();
+    const mock = vi.fn();
+
+    render(<QuestOptionButton onClick={mock} />);
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    expect(mock).toHaveBeenCalledOnce();
+  });
+
+  it('Should have active class when isActive is true', () => {
+    render(<QuestOptionButton isActive />);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass('active');
+  });
+});

--- a/src/components/QuestOptionButton/QuestOptionButton.tsx
+++ b/src/components/QuestOptionButton/QuestOptionButton.tsx
@@ -1,0 +1,23 @@
+import { type FC, type PropsWithChildren } from 'react';
+
+import { Container } from './styles';
+
+interface QuestOptionButtonTypes extends PropsWithChildren {
+  isActive: boolean;
+  onClick: () => void;
+}
+
+const QuestOptionButton: FC<QuestOptionButtonTypes> = ({
+  children,
+  isActive,
+  onClick,
+}) => (
+  <Container
+    onClick={onClick}
+    className={`quest-option${isActive ? ' active' : ''}`}
+  >
+    {children}
+  </Container>
+);
+
+export default QuestOptionButton;

--- a/src/components/QuestOptionButton/index.tsx
+++ b/src/components/QuestOptionButton/index.tsx
@@ -1,0 +1,22 @@
+import { type FC, type PropsWithChildren } from 'react';
+
+import QuestOptionButton from './QuestOptionButton';
+
+interface WrapperTypes extends PropsWithChildren {
+  isActive?: boolean;
+  onClick?: () => void;
+}
+
+const Wrapper: FC<WrapperTypes> = ({
+  children,
+  isActive = false,
+  onClick = () => {},
+}) => {
+  return (
+    <QuestOptionButton isActive={isActive} onClick={onClick}>
+      {children}
+    </QuestOptionButton>
+  );
+};
+
+export default Wrapper;

--- a/src/components/QuestOptionButton/styles.ts
+++ b/src/components/QuestOptionButton/styles.ts
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+export const Container = styled.button`
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--color-white);
+  border-radius: 100px;
+
+  padding-top: 15px;
+  padding-bottom: 15px;
+  width: 100%;
+
+  color: var(--color-white);
+  background-color: transparent;
+
+  font-weight: 500;
+  font-size: 1.25rem;
+
+  display: flex;
+  align-items: center;
+
+  transition: background-color 0.3s, border-color 0.3s;
+
+  &::before {
+    content: counter(quest-option, upper-alpha);
+
+    --size: 2.5rem;
+
+    font-size: 1.25rem;
+
+    background-color: #ffffff38;
+    width: var(--size);
+    height: var(--size);
+
+    border-radius: 50%;
+    border: 1px solid #ffffff59;
+
+    display: grid;
+    place-items: center;
+
+    margin: 0 1rem;
+
+    transition: background-color 0.3s, border-color 0.3s;
+  }
+
+  &:hover,
+  &.active {
+    border-color: #f0ced9e5;
+    background-color: #c7638333;
+
+    &::before {
+      border-color: #f0ced9e5;
+      background-color: #c7638333;
+    }
+  }
+`;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,6 +1,4 @@
-import { useState, type FC } from 'react';
-
-import QuestOptionButton from '../../components/QuestOptionButton';
+import { type FC } from 'react';
 
 import { Container } from './styles';
 
@@ -8,31 +6,10 @@ interface HomeTypes {
   initial?: number;
 }
 
-const examples = ['Evidências', 'Aparências', 'Mentiras', 'Necessidades'];
-
 const Home: FC<HomeTypes> = () => {
-  const [activeExample, setActiveExample] = useState<string | null>(null);
-
   return (
     <Container>
       <h1>Home</h1>
-
-      <ul>
-        {examples.map((example) => {
-          return (
-            <li key={example}>
-              <QuestOptionButton
-                isActive={example === activeExample}
-                onClick={() => {
-                  setActiveExample(example);
-                }}
-              >
-                {example}
-              </QuestOptionButton>
-            </li>
-          );
-        })}
-      </ul>
     </Container>
   );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,6 @@
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
+
+import QuestOptionButton from '../../components/QuestOptionButton';
 
 import { Container } from './styles';
 
@@ -6,10 +8,33 @@ interface HomeTypes {
   initial?: number;
 }
 
-const Home: FC<HomeTypes> = () => (
-  <Container>
-    <h1>Home</h1>
-  </Container>
-);
+const examples = ['Evidências', 'Aparências', 'Mentiras', 'Necessidades'];
+
+const Home: FC<HomeTypes> = () => {
+  const [activeExample, setActiveExample] = useState<string | null>(null);
+
+  return (
+    <Container>
+      <h1>Home</h1>
+
+      <ul>
+        {examples.map((example) => {
+          return (
+            <li key={example}>
+              <QuestOptionButton
+                isActive={example === activeExample}
+                onClick={() => {
+                  setActiveExample(example);
+                }}
+              >
+                {example}
+              </QuestOptionButton>
+            </li>
+          );
+        })}
+      </ul>
+    </Container>
+  );
+};
 
 export default Home;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -32,6 +32,14 @@ const GlobalStyle = createGlobalStyle`
   body {
     background-color: var(--color-primary);
     color: var(--color-white);
+    
+    ul:has(.quest-option) {
+      counter-reset: quest-option;
+
+      li {
+        counter-increment: quest-option;
+      }
+    }
   }
 
   a {


### PR DESCRIPTION
closes #4 

## What I did

Created a different component for the Quest Option Button, since it has a different purpose and different attributes (such as the active).

## How I did

Since this component is always listed, it should always be within a `ul` and `li` tag, and then it'll automatically add the circled ordered upper-cased letters (A, B, C...).

So the syntax should be:
```
<ul>
  <li><QuestOptionButton /></li>
  <li><QuestOptionButton /></li>
  <li><QuestOptionButton /></li>
</ul>
```

This happens because of the styles added to the global styles

```
body {
    background-color: var(--color-primary);
    
    ul:has(.quest-option) {
      counter-reset: quest-option;

      li {
        counter-increment: quest-option;
      }
    }
  }
```

Matching the className of the component (quest-option).
